### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: publish docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ secrets.DOCKER_HUB_NAME }}
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: publish docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           BACKEND_URL: ${{ secrets.ENV_BACKEND_URL }}
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore